### PR TITLE
Fix team naming format in tournament output

### DIFF
--- a/src/core/tourney.py
+++ b/src/core/tourney.py
@@ -110,7 +110,7 @@ class Esports(commands.Cog):
                 # fetches the teammates from embed description, currently it can can't handle the usernames, just the mentions
                 _players = message.embeds[0].description.split("\n")[-1].replace("**Players** : ", "").replace(",", " ") if message.embeds else "Added By Moderator"
                 if _captain and _team:
-                    _teams += f"{_slot},{_team},{_captain}, {_players}\n"
+                    _teams += f"{_slot},Team {_team.replace('Team ')},{_captain}, {_players}\n"
                     _slot += 1
 
             _content = "Event,Slots,Registered,Mentions,Prize\n"


### PR DESCRIPTION
This pull request includes a minor update to the `export_event_data` method in `src/core/tourney.py` to ensure consistent formatting of team names in the exported data.

### Change:
* [`src/core/tourney.py`](diffhunk://#diff-c65bcfa3212bf27afb8c378b69f6afb29f619791a23dbe37ccc88f0938f1e381L113-R113): Updated the team name formatting in the `_teams` string to ensure that any existing "Team " prefix in `_team` is removed before appending the name, while still prepending "Team " in the final output.