### PR TITLE
Add setters for tournament properties and enhance Test class structure

### DIFF
--- a/src/ext/modals.py
+++ b/src/ext/modals.py
@@ -30,80 +30,176 @@ class Tourney:
         """Returns the name of the tournament"""
         return self.obj.get("tname", "")
 
+    @tname.setter
+    def tname(self, value: str):
+        """Sets the name of the tournament"""
+        self.obj["tname"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"tname": value}})
+
     @property
-    def mentions(self)->int:
+    def mentions(self) -> int:
         """Returns the number mentions required to register in mention based tournament"""
         return self.obj.get("mentions", 0)
+
+    @mentions.setter
+    def mentions(self, value: int):
+        """Sets the number of mentions required"""
+        self.obj["mentions"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"mentions": value}})
 
     @property
     def rch(self) -> int:
         """Returns the registration channel for the tournament"""
         return self.obj.get("rch", 0)
-    
+
+    @rch.setter
+    def rch(self, value: int):
+        """Sets the registration channel"""
+        self.obj["rch"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"rch": value}})
+
     @property
     def cch(self) -> int:
         """Returns the confirmation channel for the registered teams"""
         return self.obj.get("cch", 0)
-    
+
+    @cch.setter
+    def cch(self, value: int):
+        """Sets the confirmation channel"""
+        self.obj["cch"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"cch": value}})
+
     @property
     def crole(self) -> int:
         """Returns the confirmation role for the registered teams"""
         return self.obj.get("crole", 0)
-    
+
+    @crole.setter
+    def crole(self, value: int):
+        """Sets the confirmation role"""
+        self.obj["crole"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"crole": value}})
+
     @property
     def gch(self) -> int:
         """Returns the group division channel for the tournament"""
         return self.obj.get("gch", 0)
-    
+
+    @gch.setter
+    def gch(self, value: int):
+        """Sets the group division channel"""
+        self.obj["gch"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"gch": value}})
+
     @property
     def tslot(self) -> int:
         """Returns the total slots for the tournament"""
         return self.obj.get("tslot", 0)
-    
+
+    @tslot.setter
+    def tslot(self, value: int):
+        """Sets the total slots"""
+        self.obj["tslot"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"tslot": value}})
+
     @property
     def prefix(self) -> str:
         """Returns the prefix for the tournament"""
         return self.obj.get("prefix", "")
-    
+
+    @prefix.setter
+    def prefix(self, value: str):
+        """Sets the prefix"""
+        self.obj["prefix"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"prefix": value}})
+
     @property
     def prize(self) -> str:
         """Returns the prize for the tournament"""
         return self.obj.get("prize", "")
-    
+
+    @prize.setter
+    def prize(self, value: str):
+        """Sets the prize"""
+        self.obj["prize"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"prize": value}})
+
     @property
     def faketag(self) -> str:
         """Returns the fake tag for the tournament"""
         return self.obj.get("faketag", "")
-    
+
+    @faketag.setter
+    def faketag(self, value: str):
+        """Sets the fake tag"""
+        self.obj["faketag"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"faketag": value}})
+
     @property
     def reged(self) -> int:
         """Returns the number of registered teams"""
         return self.obj.get("reged", 0)
-    
+
+    @reged.setter
+    def reged(self, value: int):
+        """Sets the number of registered teams"""
+        self.obj["reged"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"reged": value}})
+
     @property
     def status(self) -> str:
         """Returns the status of the tournament"""
         return self.obj.get("status", "")
-    
+
+    @status.setter
+    def status(self, value: str):
+        """Sets the status"""
+        self.obj["status"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"status": value}})
+
     @property
     def pub(self) -> str:
         """Returns the publication status of the tournament"""
         return self.obj.get("pub", "")
-    
+
+    @pub.setter
+    def pub(self, value: str):
+        """Sets the publication status"""
+        self.obj["pub"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"pub": value}})
+
     @property
     def spg(self) -> int:
         """Returns the slots per group for the tournament"""
         return self.obj.get("spg", 0)
-    
+
+    @spg.setter
+    def spg(self, value: int):
+        """Sets the slots per group"""
+        self.obj["spg"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"spg": value}})
+
     @property
     def auto_grp(self) -> int:
         """Returns the auto group division status of the tournament"""
         return self.obj.get("auto_grp", None)
-    
+
+    @auto_grp.setter
+    def auto_grp(self, value: int):
+        """Sets the auto group division status"""
+        self.obj["auto_grp"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"auto_grp": value}})
+
     @property
     def cgp(self) -> int:
         """Returns the current group division status of the tournament"""
         return self.obj.get("cgp", None)
+
+    @cgp.setter
+    def cgp(self, value: int):
+        """Sets the current group division status"""
+        self.obj["cgp"] = value
+        tourneys.update_one({"rch": self.rch}, {"$set": {"cgp": value}})
 
 
 class Scrim:

--- a/test/test.py
+++ b/test/test.py
@@ -1,16 +1,25 @@
-import pandas as pd
 
-# Sample JSON data (list of dictionaries)
-json_data = [
-    {"Name": "Alice", "Age": 30, "City": "New York"},
-    {"Name": "Bob", "Age": 25, "City": "Los Angeles"},
-    {"Name": "Charlie", "Age": 35, "City": "Chicago"}
-]
 
-# Create a Pandas DataFrame
-df = pd.DataFrame(json_data)
+class Test:
+    def __init__(self):
+        self._name="something"
 
-# Export DataFrame to Excel
-df.to_excel("output.xlsx", index=False, engine='openpyxl')
+    @property
+    def name(self):
+        return self._name
+    
+    @property
+    def relation(self):
+        return False
+    
+    @name.setter
+    def name(self, value):
+        self._name = value
 
-print("JSON data exported to output.xlsx")
+    
+
+i1 = Test()
+
+print(i1.name)
+i1.name = "RT"
+print(i1.name)


### PR DESCRIPTION
This pull request introduces significant updates to the `Tournament` class in `src/ext/modals.py` by adding setter methods for various tournament properties, enabling updates to both the in-memory object and the database. Additionally, it replaces a test script in `test/test.py` with a new class-based implementation. 

### Updates to `Tournament` class properties:
* Added setter methods for all properties in the `Tournament` class, such as `tname`, `mentions`, `rch`, `crole`, `prize`, etc. These setters update both the in-memory object and the corresponding database entry using `tourneys.update_one`.

### Changes in `test/test.py`:
* Replaced the previous JSON-to-Excel export functionality with a new `Test` class. The new class includes a `name` property with getter and setter methods, as well as a `relation` property. The script demonstrates the usage of these properties.