### PR TITLE
Filter out bots from the mentions of team registration

### DIFF
--- a/src/modules/message_handle.py
+++ b/src/modules/message_handle.py
@@ -205,7 +205,7 @@ async def tourney(message:Message):
         await message.delete()
         return await rch.send("**Registration Closed**")
     
-    elif len(message.mentions) >= ments:
+    elif len(valid_member_mentions) >= ments:
         for fmsg in messages:
 
             #IF DUPLICATE TAG ALLOWED

--- a/src/modules/message_handle.py
+++ b/src/modules/message_handle.py
@@ -162,37 +162,49 @@ async def duplicate_tag_check(crole, message:Message):
 
 #Tourney System
 async def tourney(message:Message):
-    if message.author.bot:return
-    elif not message.guild:return
-    td = dbc.find_one({"rch" : message.channel.id})
-    if not td :return
-    elif utils.get(message.author.roles, name="tourney-mod") : return
+    if message.author.bot or not message.guild:
+        return
+
+    td: dict[str] = dbc.find_one({"rch" : message.channel.id})
+    if not td :
+        return
+    elif utils.get(message.author.roles, name="tourney-mod") :
+        return
+
     elif td["status"] == "paused":
         try:
-            return await message.author.send("Registration Paused")
+            await message.author.send("Registration Paused")
+            return
         except Exception:
             return print(traceback.format_exc())
+        
+
     elif message.channel.id  != int(td["rch"]) or td["status"] != "started": return
     messages = [message async for message in message.channel.history(limit=2000)]
     crole = utils.get(message.guild.roles, id=int(td["crole"]))
     cch = utils.get(message.guild.channels, id = int(td["cch"]))
     rch = utils.get(message.guild.channels, id = int(td["rch"]))
-    ments = td["mentions"]
+    ments = td.get("mentions")
     rgs = td["reged"]
     tslot = td["tslot"]
+    valid_member_mentions = [mention for mention in message.mentions if not mention.bot] #filter out bots from the mentions
+
     if not crole:
         await message.author.send("Registration Paused") if message.author.dm_channel else None
         await message.reply("Confirm Role Not Found")
         return dbc.update_one({"rch" : message.channel.id}, {"$set" : {"status" : "paused"}})
+    
     elif crole in message.author.roles:
         await message.delete() if message.guild.me.guild_permissions.manage_messages else None
         return await message.channel.send("**Already Registered**", delete_after=5)
+    
     elif rgs > tslot:
         overwrite = rch.overwrites_for(message.guild.default_role)
         overwrite.update(send_messages=False)
         await rch.set_permissions(message.guild.default_role, overwrite=overwrite)
         await message.delete()
         return await rch.send("**Registration Closed**")
+    
     elif len(message.mentions) >= ments:
         for fmsg in messages:
 
@@ -252,10 +264,10 @@ async def tourney(message:Message):
                     
 
 
-    elif len(message.mentions) < ments:
+    elif len(valid_member_mentions) < ments:
         meb = Embed(description=f"**Minimum {ments} Mentions Required For Successfull Registration**", color=0xff0000)
-        try:await message.delete()
-        except Exception as e:print(f"line No 335, error: {e}")
+        await message.delete() if message.guild.me.guild_permissions.manage_messages else None
+
         return await message.channel.send(content=message.author.mention, embed=meb, delete_after=5)
 
 


### PR DESCRIPTION
This pull request refactors the `tourney` function in `src/modules/message_handle.py` to improve readability, handle edge cases more robustly, and ensure proper bot behavior during message handling in a tournament system.

### Refactoring and readability improvements:

* Combined redundant conditional checks for `message.author.bot` and `message.guild` into a single statement for clarity.
* Replaced direct dictionary indexing (`td["mentions"]`) with the safer `.get()` method to avoid potential `KeyError`.
* Introduced type annotation for `td` to clarify its expected structure (`td: dict[str]`).

### Bug fixes and edge case handling:

* Added filtering to exclude bot accounts from `message.mentions` when calculating valid member mentions (`valid_member_mentions`). This ensures bots are not considered during registration checks.
* Updated the condition for minimum mentions to use `valid_member_mentions` instead of `message.mentions`, ensuring accurate validation.

### Code consistency:

* Standardized the use of `await message.delete()` with a conditional check for `manage_messages` permissions, ensuring the bot only attempts to delete messages when permitted.