### PR TITLE
Refactor permission checks for tournament moderator role and streamli…

### DIFF
--- a/src/core/tourney.py
+++ b/src/core/tourney.py
@@ -129,7 +129,7 @@ class Esports(commands.Cog):
     @commands.command()
     @commands.guild_only()
     @commands.cooldown(2, 20, commands.BucketType.user)
-    @commands.has_role("tourney-mod")
+    @permissions.tourney_mod()
     @commands.bot_has_guild_permissions(send_messages=True, attach_files=True)
     async def export_event_data(self, ctx:commands.Context, registration_channel:discord.TextChannel):
         if ctx.author.bot:return
@@ -520,7 +520,7 @@ class Esports(commands.Cog):
 
     @commands.hybrid_command(with_app_command = True)
     @commands.guild_only()
-    @commands.has_any_role("tourney-mod")
+    @permissions.tourney_mod()
     @commands.bot_has_guild_permissions(send_messages=True)
     async def tourney(self, ctx:commands.Context, registration_channel: discord.TextChannel):
         await ctx.defer(ephemeral=True)
@@ -1075,7 +1075,7 @@ class Esports(commands.Cog):
 
     @commands.hybrid_command(with_app_command = True, aliases=["autogroup"])
     @commands.guild_only()
-    @commands.has_role("tourney-mod")
+    @permissions.tourney_mod()
     @commands.has_guild_permissions(manage_channels=True, manage_roles=True, manage_permissions=True)
     @commands.bot_has_guild_permissions(send_messages=True, manage_channels=True, manage_roles=True, manage_permissions=True)
     async def auto_group(self, ctx:commands.Context, registration_channel:discord.TextChannel):

--- a/src/ext/permissions.py
+++ b/src/ext/permissions.py
@@ -9,13 +9,12 @@
 
 
 import discord
-import discord.ext
-import discord.ext.commands
 from ext import Database
 from discord.ext import commands
 from modules import config
 db = Database()
 devs:list[int] = db.cfdata.get("devs", [])
+
 
 
 def is_dev(ctx:commands.Context):
@@ -28,6 +27,11 @@ def is_admin(ctx: commands.Context) -> bool:
         ctx.guild.owner_id == ctx.author.id or 
         is_dev(ctx)
     )
+
+
+def _is_manager(ctx:commands.Context):
+    """Check if the user is a manager"""
+    return bool(ctx.author.guild_permissions.manage_guild or ctx.guild.owner_id == ctx.author.id or is_dev(ctx))
 
 
 def has_guild_permissions(**perms: bool):
@@ -77,7 +81,7 @@ def tourney_mod():
             await ctx.send("This command can only be used in a server",ephemeral=True, delete_after=10)
             return False
         
-        if is_dev(ctx):
+        if is_dev(ctx) or is_admin(ctx) or _is_manager(ctx):
             return True
         
         return await commands.has_role("tourney-mod").predicate(ctx)


### PR DESCRIPTION
This pull request refactors the permission checks in the `tourney.py` commands and enhances the `permissions.py` module with new utility methods. The most significant change is the replacement of direct role-based checks with a new `permissions.tourney_mod()` decorator, which centralizes and simplifies permission logic.

### Refactoring of permission checks:

* Replaced `@commands.has_role("tourney-mod")` and `@commands.has_any_role("tourney-mod")` with `@permissions.tourney_mod()` in several commands in `src/core/tourney.py`. This change standardizes the permission checks for commands like `export_event_data`, `tourney`, and `auto_group`. [[1]](diffhunk://#diff-c65bcfa3212bf27afb8c378b69f6afb29f619791a23dbe37ccc88f0938f1e381L132-R132) [[2]](diffhunk://#diff-c65bcfa3212bf27afb8c378b69f6afb29f619791a23dbe37ccc88f0938f1e381L523-R523) [[3]](diffhunk://#diff-c65bcfa3212bf27afb8c378b69f6afb29f619791a23dbe37ccc88f0938f1e381L1078-R1078)

### Enhancements to `permissions.py`:

* Added a new `_is_manager(ctx:commands.Context)` function to check if a user has guild management permissions or is the guild owner. This function is also integrated into the `tourney_mod()` predicate.
* Updated the `tourney_mod()` predicate to include checks for developers, admins, and managers, enhancing its flexibility and reducing redundancy in permission logic.

### Code cleanup:

* Removed redundant imports in `src/ext/permissions.py` to streamline the code.…ne role validation logic