### PR TITLE
refactor: Remove under maintenance checks from ScrimCog commands

### DIFF
--- a/src/cogs/__init__.py
+++ b/src/cogs/__init__.py
@@ -36,7 +36,7 @@ _cogs : list[Cog] = [
 ]
 
 _DEV_COGS = [
-    ScrimCog,
+
 ]
 
 

--- a/src/cogs/esports/__init__.py
+++ b/src/cogs/esports/__init__.py
@@ -1,2 +1,8 @@
 from .scrim import ScrimCog
 from .tourney import EsportsCog
+
+
+__all__ =(
+    "ScrimCog",
+    "EsportsCog",
+)

--- a/src/cogs/esports/scrim.py
+++ b/src/cogs/esports/scrim.py
@@ -525,7 +525,6 @@ class ScrimCog(commands.GroupCog, name="scrim", group_name="scrim", command_attr
     @app.command(name="list", description="List all scrims in the server.")
     @app.guild_only()
     @checks.dev_only(interaction=True)
-    @checks.under_maintenance(interaction=True)
     async def list_scrims(self, ctx:discord.Interaction):
         """List all scrims in the server."""
         await ctx.response.defer()
@@ -948,7 +947,6 @@ class ScrimCog(commands.GroupCog, name="scrim", group_name="scrim", command_attr
     @app.command(name="reserved_slots", description="View the reserved slots for a scrim.")
     @app.guild_only()
     @checks.scrim_mod(interaction=True)
-    @checks.under_maintenance(interaction=True)
     @app.describe(reg_channel="Registration channel of the scrim to view or update reserved slots (required)")
     async def view_reserved_slots(self, ctx:discord.Interaction, reg_channel:discord.TextChannel):
         await ctx.response.defer(ephemeral=True)
@@ -1027,7 +1025,6 @@ class ScrimCog(commands.GroupCog, name="scrim", group_name="scrim", command_attr
 
     @remove_app.command(name="reserved_slots", description="View or remove a reserved slot for a scrim.")
     @app.guild_only()
-    @checks.under_maintenance(interaction=True)
     @checks.scrim_mod(interaction=True)
     @app.describe(
         reg_channel="Registration channel of the scrim to view or remove reserved slots (required)",


### PR DESCRIPTION
This pull request refactors the esports-related functionality in the `src/cogs` module, primarily focusing on improving code organization and removing unnecessary checks. The most significant changes include the addition of `__all__` for explicit exports in the `esports` package, removal of the `under_maintenance` decorator from several methods, and the exclusion of `ScrimCog` from `_DEV_COGS`.

### Code organization improvements:

* [`src/cogs/esports/__init__.py`](diffhunk://#diff-2b076910a802ab20a4ae97da92c7869fd8d0046cbf9a891e9da0d49ed4859d58R3-R8): Added `__all__` to explicitly define the exports for the `esports` package, listing `ScrimCog` and `EsportsCog`.

* [`src/cogs/__init__.py`](diffhunk://#diff-b291230a47dac0d466b8065912bf92bd6492086614ad12277bb8136f4f8248ffL39-R39): Removed `ScrimCog` from `_DEV_COGS`, suggesting that it is no longer considered a development cog.

### Simplification of scrim functionality:

* [`src/cogs/esports/scrim.py`](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135L528): Removed the `under_maintenance` decorator from the `list_scrims`, `view_reserved_slots`, and `remove_app.command` methods, streamlining the checks applied to these commands. [[1]](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135L528) [[2]](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135L951) [[3]](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135L1030)