### PR TITLE
fixes : AttributeError: 'User' object has no attribute 'roles'

### DIFF
--- a/src/ext/helper.py
+++ b/src/ext/helper.py
@@ -103,8 +103,8 @@ async def duplicate_tag(crole:discord.Role, message:discord.Message, slots=None,
     messages = [message async for message in message.channel.history(limit=slots)]
     for fmsg in messages:
 
-        # Ignore bot messages
-        if fmsg.author.bot:
+        # Ignore bot/user messages
+        if fmsg.author.bot or isinstance(fmsg.author, discord.User):
             continue
         
         if fmsg.author.id != message.author.id and crole in fmsg.author.roles:


### PR DESCRIPTION
This pull request updates the `duplicate_tag` function in `src/ext/helper.py` to improve the filtering logic for messages in a Discord channel. The change ensures that both bot messages and direct user messages are ignored during processing.

Filtering logic enhancement:

* [`src/ext/helper.py`](diffhunk://#diff-e856d0e1117ff8469a7725cecc2ea104054a54cebef4c42a69354a863981068eL106-R107): Modified the condition in `duplicate_tag` to ignore messages from bots and users (`discord.User`) to refine the message filtering process.