### PR TITLE
fix: AttributeError: 'NoneType' object has no attribute 'guild'

### DIFF
--- a/src/cogs/esports/scrim.py
+++ b/src/cogs/esports/scrim.py
@@ -1068,6 +1068,23 @@ class ScrimCog(commands.GroupCog, name="scrim", group_name="scrim", command_attr
 
         
         _channel = self.bot.get_channel(scrim.reg_channel)
+
+
+        if not _channel:
+            guild = self.bot.get_guild(scrim.guild_id)
+
+            # identify if the open time is 30 days ago or more
+            if scrim.open_time < (self.time.now(scrim.time_zone).timestamp() - int(self.scrim_interval * 30)):  # 30 days in seconds
+                await self.log(
+                    guild,
+                    f"Scrim {scrim.name} registration channel not found, and the scrim is older than 30 days. Deleting the scrim.",
+                    self.bot.color.red
+                )
+                await scrim.delete()
+                
+            self.debug(f"Scrim {scrim.name} registration channel not found. Skipping opening.")
+            return
+        
         _idp_role = _channel.guild.get_role(scrim.idp_role)
 
         if not _channel.guild.me.guild_permissions.manage_roles:

--- a/src/ext/models/scrim.py
+++ b/src/ext/models/scrim.py
@@ -286,7 +286,7 @@ class ScrimModel:
         if self.reg_channel in _scrim_cache_by_channel:
             del _scrim_cache_by_channel[self.reg_channel]
 
-        result = _scrim_col.delete_one({"reg_channel": self.reg_channel})
+        result = _scrim_col.delete_one({"reg_channel": self.reg_channel, "guild_id": self.guild_id})
         return result.deleted_count > 0
 
 


### PR DESCRIPTION
This pull request introduces improvements to the handling of scrim deletion and error logging in the `Scrim` functionality. The changes ensure that scrims with missing registration channels are properly handled and deleted if they are older than 30 days, and they enhance the precision of scrim deletion queries to avoid unintended deletions.

### Improvements to scrim handling:

* [`src/cogs/esports/scrim.py`](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135R1071-R1087): Added logic to check if the scrim's registration channel is missing. If the scrim is older than 30 days, it is logged and deleted; otherwise, the operation is skipped with a debug message.

### Enhancements to scrim deletion:

* [`src/ext/models/scrim.py`](diffhunk://#diff-66a83ae60a6f2ac215f24f3fdc3aa4a0fac1a810855895e79fbfa2cf5f7620daL289-R289): Updated the scrim deletion query to include the `guild_id` field, ensuring that deletions are scoped to the correct guild and reducing the risk of accidental deletions.