### PR TITLE
feat: Add scrim status management and improve feedback messages

### DIFF
--- a/src/cogs/esports/scrim.py
+++ b/src/cogs/esports/scrim.py
@@ -133,10 +133,11 @@ class ScrimCog(commands.GroupCog, name="scrim", group_name="scrim", command_attr
             title=f"{scrim.name}",
             color=discord.Color.green()
         )
+        status = "Open" if scrim.status==True else "Closed" if scrim.status==False else "Disabled"
         available_slots = scrim.total_slots - (len(scrim.reserved) + len(scrim.teams))
         embed.add_field(name="Open Time", value=f"<t:{scrim.open_time}:t>(<t:{scrim.open_time}:R>)")
         embed.add_field(name="Close Time", value=f"<t:{scrim.close_time}:t>(<t:{scrim.close_time}:R>)")
-        embed.add_field(name="Status", value="`Open`" if scrim.status else "`Closed`")
+        embed.add_field(name="Status", value=f"`{status}`")
         embed.add_field(name="Time Zone", value=f"`{scrim.time_zone}`")
         embed.add_field(name="Registration Channel", value=f"<#{scrim.reg_channel}>")
         embed.add_field(name="Slotlist Channel", value=f"<#{scrim.slot_channel}>")

--- a/src/cogs/esports/scrim.py
+++ b/src/cogs/esports/scrim.py
@@ -263,6 +263,44 @@ class ScrimCog(commands.GroupCog, name="scrim", group_name="scrim", command_attr
             return await ctx.followup.send(f"Unable to create scrim: {str(e)}", ephemeral=True)
         
 
+    class ScrimStatus(Enum):
+        OPEN = "open"
+        CLOSED = "closed"
+        DISABLED = "disabled"
+
+
+
+    @app.command(name="status", description="Update the status of a scrim by it's ID.")
+    @app.guild_only()
+    @checks.scrim_mod(interaction=True)
+    @app.describe(
+        reg_channel="ID of the scrim to update (required)",
+        status="New status for the scrim (required)"
+    )
+    async def update_scrim_status(self, ctx:discord.Interaction, reg_channel:discord.TextChannel, status: ScrimStatus):
+        """Update the status of a scrim by its ID."""
+        await ctx.response.defer(ephemeral=True)
+
+        _scrim = ScrimModel.find_by_reg_channel(reg_channel.id)
+
+        if not _scrim:
+            return await ctx.followup.send(self.DEFAULT_NO_SCRIM_MSG, ephemeral=True)
+
+        _status = False
+        if status == self.ScrimStatus.OPEN:
+            _status = True
+
+        elif status == self.ScrimStatus.CLOSED:
+            _status = False
+
+        elif status == self.ScrimStatus.DISABLED:
+            _status = None
+
+        _scrim.status = _status
+        await _scrim.save()
+
+        await ctx.followup.send(embed=discord.Embed(description=f"{self.bot.emoji.tick} | Scrim {reg_channel.mention} status updated to: {status.value}", color=self.bot.color.cyan), ephemeral=True)
+
 
     @app.command(name="start", description="Start a scrim by its ID.")
     @app.guild_only()
@@ -284,7 +322,7 @@ class ScrimCog(commands.GroupCog, name="scrim", group_name="scrim", command_attr
             color=self.bot.color.green
         ))
         await self.log(ctx.guild, f"Scrim `{_scrim.name}` has been started by {ctx.user.mention} in {reg_channel.mention}.")
-        await ctx.followup.send(f"Scrim {reg_channel.mention} has been started.", ephemeral=True)
+        await ctx.followup.send(embed=discord.Embed(description=f"Scrim {reg_channel.mention} has been started.", color=self.bot.color.green), ephemeral=True)
 
 
     
@@ -508,7 +546,7 @@ class ScrimCog(commands.GroupCog, name="scrim", group_name="scrim", command_attr
         #  delete the scrim from the database
         await _scrim.delete()
 
-        await ctx.followup.send(f"Scrim `{_scrim.name}` has been deleted successfully.", ephemeral=True)
+        await ctx.followup.send(embed=discord.Embed(description=f"Scrim `{_scrim.name}` has been deleted successfully.", color=self.bot.color.red), ephemeral=True)
 
 
     @app.command(name="toggle", description="Toggle the status of a scrim by its ID.")
@@ -526,8 +564,8 @@ class ScrimCog(commands.GroupCog, name="scrim", group_name="scrim", command_attr
         _scrim.status = not _scrim.status
         await _scrim.save()
         status = "opened" if _scrim.status else "closed"
-        await reg_channel.send(f"The scrim has been {status}!")
-        await ctx.followup.send(f"Scrim {reg_channel.mention} has been {status}.", ephemeral=True)
+        await reg_channel.send(embed=discord.Embed(description=f"The scrim has been {status}!", color=self.bot.color.green))
+        await ctx.followup.send(embed=discord.Embed(description=f"Scrim {reg_channel.mention} has been {status}.", color=self.bot.color.green), ephemeral=True)
 
 
 
@@ -565,6 +603,11 @@ class ScrimCog(commands.GroupCog, name="scrim", group_name="scrim", command_attr
                     self.update_button_states()
                     await interaction.response.edit_message(embed=embed, view=self)
 
+            @discord.ui.button(emoji="✅", label="Done", style=discord.ButtonStyle.success)
+            async def done_button(self, interaction:discord.Interaction, button:discord.ui.Button):
+                # delete all the views
+                await interaction.message.delete()
+                self.stop()
 
             @discord.ui.button(emoji="🗑️", label="Delete", style=discord.ButtonStyle.danger)
             async def delete_button(self, interaction:discord.Interaction, button:discord.ui.Button):

--- a/src/cogs/esports/tourney.py
+++ b/src/cogs/esports/tourney.py
@@ -441,28 +441,32 @@ class EsportsCog(commands.Cog):
         await ctx.defer(ephemeral=True)
         if ctx.author.bot:return
 
-        tmrole = discord.utils.get(ctx.guild.roles, name="tourney-mod")
-        if tmrole == None:tmrole = await ctx.guild.create_role("tourney-mod")
-        if ctx.author.guild_permissions.manage_channels or tmrole in ctx.author.roles:
-            dbcd:dict[str] = self.dbc.find_one({"rch" : registration_channel.id})
-            if not dbcd:
-                return await ctx.send(embed=discord.Embed(description=f"**{self._tnotfound}**", color=color.red), delete_after=10)
-            crole = discord.utils.get(ctx.guild.roles, id=int(dbcd["crole"]))
-            if not crole:
-                return await ctx.send("Confirm Role Not Found", delete_after=10)
-            reged = dbcd.get("reged")
-            cch = discord.utils.get(ctx.guild.channels, id=int(dbcd["cch"]))
-            if crole in member.roles:
-                return await ctx.send("**Already Registered**", delete_after=50)
-            if crole not in member.roles:
-                await member.add_roles(crole)
-                self.dbc.update_one({"rch" : registration_channel.id}, {"$set" : {"reged" : reged + 1}})
-                emb = discord.Embed(color=0xffff00, description=f"**{reged}) TEAM NAME: {team_name.upper()}**\n**Added By** : {ctx.author.mention} ")
-                emb.set_author(name=ctx.guild.name, icon_url=ctx.guild.icon)
-                emb.timestamp = datetime.datetime.now()
-                await cch.send(f"{team_name} {member.mention}", embed=emb)
-                await ctx.send(f"**{reged}){team_name}{member.mention} Added**", delete_after=50)   
-            
+        dbcd:dict[str] = self.dbc.find_one({"rch" : registration_channel.id})
+        if not dbcd:
+            return await ctx.send(embed=discord.Embed(description=f"**{self._tnotfound}**", color=color.red), delete_after=10)
+        
+        crole = discord.utils.get(ctx.guild.roles, id=int(dbcd["crole"]))
+        if not crole:
+            return await ctx.send("Confirm Role Not Found", delete_after=10)
+        
+        reged = dbcd.get("reged")
+        cch = discord.utils.get(ctx.guild.channels, id=int(dbcd["cch"]))
+
+        if not cch:
+            return await ctx.send(embed=discord.Embed(description="**Confirm Channel Not Found**", color=color.red), delete_after=10)
+    
+        if crole in member.roles:
+            return await ctx.send("**Already Registered**", delete_after=50)
+        
+        if crole not in member.roles:
+            await member.add_roles(crole)
+            self.dbc.update_one({"rch" : registration_channel.id}, {"$set" : {"reged" : reged + 1}})
+            emb = discord.Embed(color=0xffff00, description=f"**{reged}) TEAM NAME: {team_name.upper()}**\n**Added By** : {ctx.author.mention} ")
+            emb.set_author(name=ctx.guild.name, icon_url=ctx.guild.icon)
+            emb.timestamp = datetime.datetime.now()
+            await cch.send(f"{team_name} {member.mention}", embed=emb)
+            await ctx.send(f"**{reged}){team_name}{member.mention} Added**", delete_after=50)   
+        
 
 
     @commands.hybrid_command(name="tourneys", description="Get Ongoing Tournaments in Your DM")


### PR DESCRIPTION
This pull request introduces a new command for updating scrim statuses, improves the user interface by using embedded messages across several commands, and adds a "Done" button to the scrim view. It also removes unnecessary role-checking logic in the tournament module. Below is a summary of the most important changes:

### New Feature: Scrim Status Update
* Added the `update_scrim_status` command in `src/cogs/esports/scrim.py`, allowing users to update the status of a scrim (`OPEN`, `CLOSED`, or `DISABLED`) via a new `ScrimStatus` enum. The command validates the scrim ID and updates its status in the database.

### UI Enhancements: Embedded Messages
* Replaced plain text responses with embedded messages in the `start_scrim`, `delete_scrim`, and `toggle_scrim` commands to improve the visual presentation of bot responses in `src/cogs/esports/scrim.py`. [[1]](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135L287-R325) [[2]](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135L511-R549) [[3]](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135L529-R568)

### New UI Interaction: "Done" Button
* Added a "Done" button to the scrim view in `src/cogs/esports/scrim.py`. This button allows users to delete the view and stop the interaction, improving user experience.

### Code Simplification: Role-Checking Logic
* Removed redundant role-checking logic in the `add_slot` method of `src/cogs/esports/tourney.py`, simplifying the code and ensuring it focuses on essential functionality.