### PR TITLE
fix: Sync scrim open and close times to the next day if they are behi…

### DIFF
--- a/src/modules/message_handle.py
+++ b/src/modules/message_handle.py
@@ -6,17 +6,16 @@ of this license document, but changing it is not allowed.
 """
 
 import re, traceback
-from datetime import timedelta
 from typing import TYPE_CHECKING
 from ext.modals import Tourney
-from discord import utils, AllowedMentions, Embed, Message, TextChannel
+from discord import utils, Embed, Message, TextChannel
 from ext import helper, color as Color
 
 
 if TYPE_CHECKING:
     from modules.bot import Spruce
 
-IS_DEBUG = True
+IS_DEBUG = False
 
 async def get_prize(cch:TextChannel):
     info = cch.category.channels[0]
@@ -202,9 +201,3 @@ async def tourney(message: Message, bot: 'Spruce'):
     await cch.send(f"{team_name.upper()} {message.author.mention}", embed=embed)
 
     await log_event(message, f"{message.author} registered in {rch.mention} with team name {team_name}.", color=bot.color.green)
-
-
-################# NITRO ######################
-async def nitrof(message:Message, bot:'Spruce'):
-    #  Temporarily disabled for some future performance optimizations
-    pass


### PR DESCRIPTION
This pull request introduces several updates to the `src/cogs/esports/scrim.py` and `src/modules/message_handle.py` files, focusing on improving scrim management functionality and cleaning up unused code. The most significant changes include syncing scrim open and close times when they are outdated, toggling scrim statuses more robustly, and removing unused methods to streamline the codebase. and fixes #121 

### Scrim management enhancements:
* **Sync outdated scrim open and close times**: Added logic in both `update_scrim_status` and `toggle_scrim` methods to adjust scrim open and close times to the next day if they are outdated. This ensures scrim times remain relevant and avoids scheduling conflicts. (`src/cogs/esports/scrim.py`, [[1]](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135R293-R304) [[2]](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135R596-R615)

### Code cleanup:
* **Removed unused imports**: Eliminated the unused `timedelta` import from `src/modules/message_handle.py` to reduce clutter. (`src/modules/message_handle.py`, [src/modules/message_handle.pyL9-R18](diffhunk://#diff-656eec1b7a1b1dc12442dcb7e55e9c4ed2e90962c0b98e70a06ee038a4d6d7bfL9-R18))
* **Removed unused `nitrof` method**: Deleted the `nitrof` method, which was temporarily disabled, to simplify the codebase and improve maintainability. (`src/modules/message_handle.py`, [src/modules/message_handle.pyL205-L210](diffhunk://#diff-656eec1b7a1b1dc12442dcb7e55e9c4ed2e90962c0b98e70a06ee038a4d6d7bfL205-L210))

### Configuration update:
* **Updated debug flag**: Changed `IS_DEBUG` from `True` to `False` in `src/modules/message_handle.py`, likely reflecting a shift to production mode or disabling debug logs. (`src/modules/message_handle.py`, [src/modules/message_handle.pyL9-R18](diffhunk://#diff-656eec1b7a1b1dc12442dcb7e55e9c4ed2e90962c0b98e70a06ee038a4d6d7bfL9-R18))
