### PR TITLE
feat(scrim, tourney): add ignore command for scrim mod and tournament

### DIFF
--- a/src/cogs/music.py
+++ b/src/cogs/music.py
@@ -11,8 +11,9 @@ from threading import Thread
 from typing import cast, TYPE_CHECKING
 from time import gmtime, strftime
 from discord.ext import commands
+import wavelink.websocket
 from ext.error import update_error_log
-from discord import ButtonStyle, Interaction, Embed, Message, TextChannel, Member
+from discord import utils, ButtonStyle, Interaction, Embed, Message, TextChannel, Member
 from discord.ui import Button, View
 
 if TYPE_CHECKING:
@@ -33,6 +34,7 @@ class MusicCog(commands.Cog):
         self.message:Message  = None
         self.loop:bool = False
         self.players : dict[int, wavelink.Player] = {}
+        wavelink.websocket.logger.setLevel(100)  # Disable Wavelink's internal logging
 
         self.controlButtons = [
             Button(emoji=self.bot.emoji.next_btn, custom_id="music_next_btn"),
@@ -204,7 +206,7 @@ class MusicCog(commands.Cog):
         home : TextChannel = player.home
         embed = Embed(
             title=f"{self.bot.emoji.music_disk} Now Playing", 
-            color=self.bot.color.cyan, description=f'**[{track.title}]({self.bot.config.INVITE_URL})**\nDuration : {self.bot.time.by_seconds(track.length//1000)}\n').set_thumbnail(url=track.artwork)
+            color=self.bot.color.cyan, description=f'**[{track.title}]({self.bot.config.INVITE_URL})**\nDuration : <t:{int(utils.utcnow().timestamp() + track.length//1000)}:R>\n').set_thumbnail(url=track.artwork)
         view = View(timeout=60)
 
         for button in self.controlButtons:

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ from modules.bot import Spruce
 
 async def launch():
     try:
-        bot = Spruce(lavalink=False)
+        bot = Spruce(lavalink=True)
         await bot.start(_start)
         
     except Exception as e:

--- a/src/modules/bot.py
+++ b/src/modules/bot.py
@@ -159,7 +159,6 @@ class Spruce(commands.AutoShardedBot):
 
 
     async def on_lavalink_callback(self) -> None:
-        print("Lavalink callback received, connecting to Lavalink server...")
         try:
             self.logger.info("Connecting to Lavalink...")
             _nodes = [wavelink.Node(uri=self.config.LOCAL_LAVA[0], password=self.config.LOCAL_LAVA[1])]
@@ -167,7 +166,6 @@ class Spruce(commands.AutoShardedBot):
 
         except Exception as e:
             self.logger.error(f"Failed to connect to Lavalink: {e}")
-            self.error_log(f"Failed to connect to Lavalink: {e}")
             self.unload_extension("cogs.music")
 
 

--- a/src/modules/message_handle.py
+++ b/src/modules/message_handle.py
@@ -78,7 +78,7 @@ async def tourney(message: Message, bot: 'Spruce'):
         return
     
 
-    if utils.get(message.author.roles, name="tourney-tag-ignore"):
+    if utils.get(message.author.roles, name=bot.config.TAG_IGNORE_ROLE):
         return
 
     tournament = Tourney.findOne(message.channel.id)


### PR DESCRIPTION
This pull request introduces several updates across multiple modules, focusing on adding a new "ignore role" feature for scrim and tournament commands, improving error handling, and refining the music bot's functionality. Below is a breakdown of the most important changes:

### New "Ignore Role" Feature for Scrim and Tournament Commands
* Added a new `ignore_me` command in both `scrim.py` and `tourney.py` to allow users to ignore scrim and tournament registration channels. The command creates or retrieves a role (`TAG_IGNORE_ROLE`) and assigns it to the user. It also checks for role hierarchy issues before proceeding. (`[[1]](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135R696-R729)`, `[[2]](diffhunk://#diff-4d0dc56d483143254eabe5ea66f10b48edf1b5d805bfa42d3bb87214e5e86cefR355-R388)`)
* Introduced a new constant `HIGHER_ROLE_POSITION` in `scrim.py` and `tourney.py` to handle role hierarchy error messages. (`[[1]](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135R42)`, `[[2]](diffhunk://#diff-4d0dc56d483143254eabe5ea66f10b48edf1b5d805bfa42d3bb87214e5e86cefR58)`)
* Updated logic in `on_message` handlers to check for the `TAG_IGNORE_ROLE` dynamically from the bot's configuration instead of hardcoding the role name. (`[[1]](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135L1279-R1314)`, `[[2]](diffhunk://#diff-656eec1b7a1b1dc12442dcb7e55e9c4ed2e90962c0b98e70a06ee038a4d6d7bfL81-R81)`)

### Music Bot Enhancements
* Disabled Wavelink's internal logging by setting its logger level to 100, reducing unnecessary log clutter. (`[src/cogs/music.pyR37](diffhunk://#diff-9c416b8c61911e30ce2a1326b76c97a2d1715bfd0c27dbe8736633bb03035abfR37)`)
* Improved the "Now Playing" embed to display the track's remaining duration using a relative timestamp format (`<t:...:R>`). (`[src/cogs/music.pyL207-R209](diffhunk://#diff-9c416b8c61911e30ce2a1326b76c97a2d1715bfd0c27dbe8736633bb03035abfL207-R209)`)
* Enabled Lavalink in the bot's main entry point by setting `lavalink=True` during initialization. (`[src/main.pyL22-R22](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L22-R22)`)

### Error Handling Improvements
* Added a try-except block in the scrim registration process to handle cases where the confirmation reaction cannot be added, logging the error instead of failing silently. (`[src/cogs/esports/scrim.pyL1362-R1405](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135L1362-R1405)`)
* Removed redundant print statements and error log calls for Lavalink connection issues, streamlining the logging process. (`[src/modules/bot.pyL162-L170](diffhunk://#diff-7c6e322a3990a5db994020b296e5156b7a2766a5c4e721c712ef04c1787cc7aeL162-L170)`)

### Minor Refactor
* Updated imports in `music.py` to include `discord.utils` for utility functions. (`[src/cogs/music.pyR14-R16](diffhunk://#diff-9c416b8c61911e30ce2a1326b76c97a2d1715bfd0c27dbe8736633bb03035abfR14-R16)`)