### PR TITLE
feat(cogs): add cog loading command and improve error handling in mus…

### DIFF
--- a/src/cogs/__init__.py
+++ b/src/cogs/__init__.py
@@ -41,7 +41,7 @@ _cogs : list["Cog"] = [
 ]
 
 _DEV_COGS = [
-    MusicCog,
+
 ]
 
 

--- a/src/cogs/dev.py
+++ b/src/cogs/dev.py
@@ -26,7 +26,12 @@ class Plans(enum.Enum):
     Yearly = 429
     Lifetime = 4444
     Custom = 0
-    
+
+class CogEnum(enum.Enum):
+    music = "music"
+    moderation = "moderation"
+    utility = "utility"
+
 
 class DevCog(commands.Cog):
     """
@@ -263,3 +268,16 @@ Disk Usage: {disk.used//10**9} GB({disk.percent}%)
         await ctx.send(file=discord.File("error.log"))
 
 
+    @discord.app_commands.command(name="load_cog", description="(Dev only): Load a cog by name")
+    @checks.dev_only()
+    @discord.app_commands.describe(cog_name="Name of the cog to load")
+    async def load_cog(self, ctx: discord.Interaction, cog_name: CogEnum):
+        if ctx.user.bot or ctx.user.id not in self.bot.config.DEVELOPERS:
+            return await ctx.response.send_message("You are not allowed to use this command.", ephemeral=True)
+        
+        try:
+            await self.bot.load_extension(f"cogs.{cog_name.value}")
+            await ctx.response.send_message(f"Cog `{cog_name.value}` loaded successfully.", ephemeral=True)
+
+        except Exception as e:
+            await ctx.response.send_message(f"Failed to load cog `{cog_name.value}`: {e}", ephemeral=True)

--- a/src/cogs/esports/scrim.py
+++ b/src/cogs/esports/scrim.py
@@ -791,7 +791,7 @@ class ScrimCog(commands.GroupCog, name="scrim", group_name="scrim", command_attr
             name=f"{event_prefix}-idp",
             category=reg_channel.category,
         )
-        idp_channel.set_permissions(
+        await idp_channel.set_permissions(
             ctx.guild.default_role,
             send_messages=False,
             read_messages=True


### PR DESCRIPTION
This pull request introduces several updates across multiple files, focusing on improving functionality in the `dev`, `music`, and `esports` cogs. Key changes include adding a new cog-loading command for developers, enhancing error handling in music playback, and fixing permission-setting behavior in the esports cog.

### Dev Cog Enhancements:
* Added a `CogEnum` class in `src/cogs/dev.py` to define a set of valid cog names (`music`, `moderation`, `utility`) for easier cog management.
* Introduced a new `/load_cog` command in `src/cogs/dev.py` for developers to dynamically load cogs by name, with proper access checks and error handling.

### Music Cog Improvements:
* Enhanced error handling in the `play` command in `src/cogs/music.py` to catch `wavelink.LavalinkLoadException` and provide user-friendly feedback when tracks fail to load.
* Refactored the `on_interaction` method in `src/cogs/music.py` to improve the formatting of the queue display, replacing embed fields with a single description for better readability.

### Esports Cog Fix:
* Fixed an issue in `src/cogs/esports/scrim.py` where `set_permissions` was not awaited, ensuring proper asynchronous behavior when setting channel permissions.