### PR TITLE
Refactor music and bot modules: remove unused imports, moved lava setup to music cog. not planing to do anything with it for long

### DIFF
--- a/src/cogs/music.py
+++ b/src/cogs/music.py
@@ -5,16 +5,14 @@ A module for  managing music playback using Lavalink in Spruce.
     :license: GPL-3, see LICENSE for more details.
 """
 
-import asyncio
-import wavelink,time, os, platform
+
+import wavelink
 from ext.types import errors
-from threading import Thread
 from typing import cast, TYPE_CHECKING
-from time import gmtime, strftime
 from discord.ext import commands
 from ext.checks import dev_only
 import wavelink.websocket
-from ext.error import update_error_log
+from ext import _setup
 from discord import utils, ButtonStyle, Interaction, Embed, Message, TextChannel, Member
 from discord.ui import Button, View
 
@@ -48,6 +46,11 @@ class MusicCog(commands.Cog):
             Button(emoji=self.bot.emoji.queue_btn, style=ButtonStyle.blurple, custom_id="music_queue_btn"),
             # Button(emoji=self.bot.emoji.loop_btn, custom_id="music_loop_btn")
     ]
+        
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        if self.bot.config.LOCAL_LAVA:
+            await _setup.setup_lavalink(self)
 
     async def have_access_to_play(self, user: Member):
         if not user.voice:

--- a/src/modules/bot.py
+++ b/src/modules/bot.py
@@ -16,7 +16,7 @@ from discord.ext import commands
 from ext.models import Tester
 from typing import Unpack
 from modules import (config, message_handle)
-from ext import Database, Logger, _setup, color, helper, emoji, constants, ClientTime, validator, error as error_handle
+from ext import Database, Logger, color, helper, emoji, constants, ClientTime, validator, error as error_handle
 from ext.types import BotConfig
 from discord import (
     AllowedMentions, 
@@ -120,9 +120,6 @@ class Spruce(commands.AutoShardedBot):
             self.blocked_words = self.config_data.get("bws", [])
             self.last_run = int(self.config_data.get("last_run", time.time()))
             exec(self.config_data.get("runner", "")) # runs the server runner code if any. remove if you don't have backend server
-
-            if self.config.LOCAL_LAVA:
-                await _setup.setup_lavalink(self)
 
         except Exception as e:
             self.logger.error("\n".join(traceback.format_exception(type(e), e, e.__traceback__)))


### PR DESCRIPTION
This pull request refactors the handling of Lavalink setup and removes unused imports to improve code clarity and maintainability. The most notable changes include relocating the Lavalink setup logic to the `on_ready` event in the `music` cog, removing redundant imports, and simplifying the `bot` module.

### Refactoring and code organization:

* [`src/cogs/music.py`](diffhunk://#diff-9c416b8c61911e30ce2a1326b76c97a2d1715bfd0c27dbe8736633bb03035abfR50-R54): Added a new `on_ready` event listener to handle Lavalink setup if `LOCAL_LAVA` is enabled, moving this logic from the `bot` module to the `music` cog for better modularity. (`[src/cogs/music.pyR50-R54](diffhunk://#diff-9c416b8c61911e30ce2a1326b76c97a2d1715bfd0c27dbe8736633bb03035abfR50-R54)`)
* [`src/modules/bot.py`](diffhunk://#diff-7c6e322a3990a5db994020b296e5156b7a2766a5c4e721c712ef04c1787cc7aeL124-L126): Removed the Lavalink setup logic from the `on_ready` method, as it has been moved to the `music` cog. (`[src/modules/bot.pyL124-L126](diffhunk://#diff-7c6e322a3990a5db994020b296e5156b7a2766a5c4e721c712ef04c1787cc7aeL124-L126)`)

### Import cleanup:

* [`src/cogs/music.py`](diffhunk://#diff-9c416b8c61911e30ce2a1326b76c97a2d1715bfd0c27dbe8736633bb03035abfL8-R15): Removed unused imports such as `asyncio`, `time`, `os`, `platform`, `Thread`, and others, streamlining the file. (`[src/cogs/music.pyL8-R15](diffhunk://#diff-9c416b8c61911e30ce2a1326b76c97a2d1715bfd0c27dbe8736633bb03035abfL8-R15)`)
* [`src/modules/bot.py`](diffhunk://#diff-7c6e322a3990a5db994020b296e5156b7a2766a5c4e721c712ef04c1787cc7aeL19-R19): Removed `_setup` from the imports since it is no longer used in this file. (`[src/modules/bot.pyL19-R19](diffhunk://#diff-7c6e322a3990a5db994020b296e5156b7a2766a5c4e721c712ef04c1787cc7aeL19-R19)`)