### PR TITLE
 improve response handling in various cogs

### DIFF
--- a/src/cogs/dev.py
+++ b/src/cogs/dev.py
@@ -46,10 +46,9 @@ class DevCog(commands.Cog):
 
     @discord.app_commands.command(description="Use coupon code SP10 to get Discount.")
     @checks.dev_only()
-    async def getprime(self, interaction:discord.Interaction, plan:Plans):
-        ctx = interaction
-        if ctx.user.bot or ctx.user.id not in self.bot.devs:return
-        amount = plan.value if (interaction.user.id != config.OWNER_ID) else 1
+    async def getprime(self, ctx:discord.Interaction, plan:Plans):
+        await ctx.response.defer()
+        amount = plan.value if (ctx.user.id != config.OWNER_ID) else 1
         url:str = f"{config.BASE_URL}/extras/pg.html?session="
         if plan != Plans.Custom:
             url += payment.create_order(
@@ -60,7 +59,7 @@ class DevCog(commands.Cog):
         if plan == Plans.Custom:
             url = config.SUPPORT_SERVER
         button:discord.ui.Button = discord.ui.Button(label="Get Prime", url=url)
-        await interaction.response.send_message(
+        await ctx.followup.send(
             embed=discord.Embed(
                 title="Get Prime", 
                 description="Click the button to get prime", 

--- a/src/cogs/esports/scrim.py
+++ b/src/cogs/esports/scrim.py
@@ -305,8 +305,8 @@ class ScrimCog(commands.GroupCog, name="scrim", group_name="scrim", command_attr
             behind_close_days = datetime.fromtimestamp(max(current_time - _scrim.close_time, 0)).day
             behind_open_days = datetime.fromtimestamp(max(current_time - _scrim.open_time, 0)).day
 
-            _scrim.open_time = _scrim.open_time + timedelta(days=behind_open_days).total_seconds()
-            _scrim.close_time = _scrim.close_time + timedelta(days=behind_close_days).total_seconds()
+            _scrim.open_time = _scrim.open_time + int(timedelta(days=behind_open_days).total_seconds()) #fixed ValueError Expected an integer, got float.
+            _scrim.close_time = _scrim.close_time + int(timedelta(days=behind_close_days).total_seconds())
 
         _status = False
         if status == self.ScrimStatus.OPEN:

--- a/src/cogs/music.py
+++ b/src/cogs/music.py
@@ -262,11 +262,12 @@ class MusicCog(commands.Cog):
 
 
     async def interaction_next(self, interaction: Interaction) -> None:
+        await interaction.response.defer()
         player: wavelink.Player = cast(wavelink.Player, interaction.guild.voice_client)
 
         if not player.queue.is_empty:
             await player.skip(force=True)
-            return await interaction.response.send_message("Skipped to the next track.", ephemeral=True)
+            return await interaction.followup.send("Skipped to the next track.", ephemeral=True)
         
         await player.skip(force=True)
 

--- a/src/cogs/role.py
+++ b/src/cogs/role.py
@@ -218,6 +218,7 @@ class RoleCog(commands.Cog):
     @commands.bot_has_guild_permissions(manage_roles=True, send_messages=True)
     @app_commands.describe(role="The role to remove from all members fom", reason="The reason for removing the role")
     async def remove_members(self, interaction: Interaction, role: Role, reason: str = None):
+        await interaction.response.defer(ephemeral=True)
         if interaction.user.bot:
             return
         
@@ -225,7 +226,7 @@ class RoleCog(commands.Cog):
             self.check_access(interaction.user, role)
 
         except Exception as e:
-            return await interaction.response.send_message(
+            return await interaction.followup.send(
                 embed=Embed(
                     description=str(e),
                     color=self.bot.color.red

--- a/src/ext/error.py
+++ b/src/ext/error.py
@@ -199,10 +199,16 @@ async def handle_interaction_error(interaction: Interaction, error: app_commands
         await interaction.response.send_message(embed=Embed(color=0xff0000, description=str(error).replace("Bot", bot.user.name)), ephemeral=True)
 
     else:
-        await interaction.response.send_message(
-            embed=Embed(color=0xff0000, description="I'm sorry, but currently I'm facing some issues. Please try again later."),
-            ephemeral=True
-        )
+        if interaction.response.is_done():
+            await interaction.followup.send(
+                embed=Embed(color=0xff0000, description="I'm sorry, but currently I'm facing some issues. Please try again later."),
+                ephemeral=True
+            )
+        else:
+            await interaction.response.send_message(
+                embed=Embed(color=0xff0000, description="I'm sorry, but currently I'm facing some issues. Please try again later."),
+                ephemeral=True
+            )
         async with aiofiles.open(ERROR_FP, "w", encoding="utf-8") as file: 
             await file.write("\n".join(traceback.format_exception(error)))
  


### PR DESCRIPTION
This pull request introduces several improvements and fixes across multiple files to enhance interaction handling, address type errors, and streamline the user experience. The most important changes include ensuring deferred responses in interactions, fixing type-related errors, and improving error handling for better user feedback.

### Interaction Handling Improvements:
* [`src/cogs/dev.py`](diffhunk://#diff-5ba6273eba92569822f2c961ec8bb4a3d7ddc89bdd051899ed5cb88f847bfbbaL49-R51): Changed `interaction.response.send_message` to `ctx.followup.send` and added `ctx.response.defer()` to ensure deferred responses are handled properly in the `getprime` command. [[1]](diffhunk://#diff-5ba6273eba92569822f2c961ec8bb4a3d7ddc89bdd051899ed5cb88f847bfbbaL49-R51) [[2]](diffhunk://#diff-5ba6273eba92569822f2c961ec8bb4a3d7ddc89bdd051899ed5cb88f847bfbbaL63-R62)
* [`src/cogs/music.py`](diffhunk://#diff-9c416b8c61911e30ce2a1326b76c97a2d1715bfd0c27dbe8736633bb03035abfR265-R270): Updated `interaction.response.send_message` to `interaction.followup.send` and added `interaction.response.defer()` in `interaction_next` to improve interaction handling during music playback.
* [`src/cogs/role.py`](diffhunk://#diff-20a27767045d8524d1f651519ae8859c49c1a582244ed437de9ebf028da43227R221-R229): Added `interaction.response.defer(ephemeral=True)` and replaced `interaction.response.send_message` with `interaction.followup.send` in `remove_members` for better handling of role removal interactions.

### Type Error Fixes:
* [`src/cogs/esports/scrim.py`](diffhunk://#diff-9c0a968605a2cc652455dff08788a74edeb5e20966268665627370882a066135L308-R309): Fixed `ValueError` by explicitly converting `timedelta.total_seconds()` to an integer in `update_scrim_status`. This ensures compatibility with expected integer types.

### Enhanced Error Handling:
* [`src/ext/error.py`](diffhunk://#diff-6c89421a5be035434f1f58740d9cdf6d9defb61d5dbefd6aa57b1c6ac0695e76R201-R206): Improved error handling by adding a fallback to `interaction.followup.send` if `interaction.response.is_done()` is true, ensuring users receive feedback even when the initial response fails.