### PR TITLE
Enhance moderation commands: Add permission checks for channel manage…

### DIFF
--- a/src/cogs/moderation.py
+++ b/src/cogs/moderation.py
@@ -9,6 +9,7 @@ import time
 import discord
 from discord import app_commands
 from asyncio import sleep
+from ext import EmbedBuilder
 from discord.ext import commands
 import typing
 
@@ -473,6 +474,22 @@ class ModerationCog(commands.Cog):
 
 
         async def dc_confirmed(interaction:discord.Interaction):
+
+            if interaction.user.id != ctx.author.id:
+                await interaction.response.send_message(
+                    embed=EmbedBuilder.warning(f"{self.bot.emoji.cross} | You are not allowed to do this"),
+                    ephemeral=True
+                )
+                return
+            
+            if not ctx.guild.me.guild_permissions.manage_channels:
+                await interaction.response.send_message(
+                    embed=EmbedBuilder.warning(f"I don't have permission to manage channels"),
+                    ephemeral=True
+                )
+                return
+            
+
             emb = discord.Embed(color=0x00ff00, description=f"**{self.bot.emoji.loading} | Deleting `{category.name}` Category**")
             await del_t_con.edit(content=None, embed=emb, view=None)
             for channel in category.channels:


### PR DESCRIPTION
This pull request introduces changes to enhance the moderation cog in `src/cogs/moderation.py`. The updates include the addition of a utility for building embeds and improved validation checks in the `delete_category` command to ensure proper permissions and user validation.

### Utility Addition:
* Added `EmbedBuilder` import from `ext` to facilitate the creation of warning and informational embeds. (`[src/cogs/moderation.pyR12](diffhunk://#diff-6b6c8e9c427ff99063a8857a5a6eba2d1c46923b81da9ef3a69c801f2f807921R12)`)

### Command Enhancements:
* Updated the `delete_category` command with the following validation checks:
  * Ensures that only the command invoker can interact with the confirmation prompt. (`[src/cogs/moderation.pyR477-R492](diffhunk://#diff-6b6c8e9c427ff99063a8857a5a6eba2d1c46923b81da9ef3a69c801f2f807921R477-R492)`)
  * Validates that the bot has the `manage_channels` permission before proceeding with category deletion. (`[src/cogs/moderation.pyR477-R492](diffhunk://#diff-6b6c8e9c427ff99063a8857a5a6eba2d1c46923b81da9ef3a69c801f2f807921R477-R492)`)