### PR TITLE
Development

### DIFF
--- a/src/cogs/esports/tourney.py
+++ b/src/cogs/esports/tourney.py
@@ -1302,7 +1302,7 @@ class TourneyCog(commands.GroupCog, name="tourney", group_name="tourney"):
         limit = _event.reged - (base_index + _event.spg)
         messages: list[Message] = []
         
-        async for message in confirm_channel.history(limit=limit+1):
+        async for message in confirm_channel.history(limit=limit+_event.spg, oldest_first=True):
             if all([message.author == ctx.guild.me, message.mentions]):
                 messages.append(message)
 
@@ -1311,7 +1311,6 @@ class TourneyCog(commands.GroupCog, name="tourney", group_name="tourney"):
         if shuffle:
             random_shuffle(messages)
 
-        messages.reverse()
         total_messages = len(messages)
 
         if base_index > total_messages:


### PR DESCRIPTION
This pull request makes adjustments to the `auto_group` function in `src/cogs/esports/tourney.py` to improve message handling and ensure proper ordering when processing messages. The most important changes include modifying the `confirm_channel.history` call to include the `oldest_first` parameter and removing the unnecessary `messages.reverse()` operation.

### Improvements to message handling:

* Updated the `confirm_channel.history` call to include the `oldest_first=True` parameter, ensuring messages are retrieved in chronological order. Additionally, adjusted the `limit` calculation to account for `_event.spg`. (`[src/cogs/esports/tourney.pyL1305-R1305](diffhunk://#diff-4d0dc56d483143254eabe5ea66f10b48edf1b5d805bfa42d3bb87214e5e86cefL1305-R1305)`)

* Removed the redundant `messages.reverse()` operation, as messages are now retrieved in the correct order using the `oldest_first` parameter. (`[src/cogs/esports/tourney.pyL1314](diffhunk://#diff-4d0dc56d483143254eabe5ea66f10b48edf1b5d805bfa42d3bb87214e5e86cefL1314)`)