### PR TITLE
Enhance bot startup performance: Disable chunking guilds at startup.

### DIFF
--- a/src/cogs/music.py
+++ b/src/cogs/music.py
@@ -66,6 +66,17 @@ class MusicCog(commands.Cog):
             await user.voice.channel.connect(cls=wavelink.Player, self_deaf=True)
 
 
+    @commands.Cog.listener()
+    async def on_lavalink_callback(self) -> None:
+        try:
+            self.bot.logger.info("Connecting to Lavalink...")
+            _nodes = [wavelink.Node(uri=self.bot.config.LOCAL_LAVA[0], password=self.bot.config.LOCAL_LAVA[1])]
+            await wavelink.Pool.connect(nodes=_nodes, client=self, cache_capacity=None)
+
+        except Exception as e:
+            self.bot.logger.error(f"Failed to connect to Lavalink: {e}")
+            await self.bot.unload_extension("cogs.music")
+
 
     @commands.hybrid_command(name="join", aliases=["j"], description="Join a voice channel.")
     async def join(self, ctx: commands.Context) -> None:


### PR DESCRIPTION
This pull request introduces several updates to enhance functionality, improve error handling, and streamline the codebase for the bot. The most important changes include adding a Lavalink connection listener, optimizing guild chunking during startup, improving error logging, and removing unused or redundant code.

### Lavalink Integration and Guild Chunking:
* Added `on_lavalink_callback` listener in `src/cogs/music.py` to handle Lavalink connection setup with error handling. This ensures the bot connects to Lavalink nodes properly and logs any connection issues.
* Enabled guild chunking during startup in `src/core/bot.py` to improve performance and logging, ensuring all guilds are chunked successfully.

### Code Simplification and Cleanup:
* Removed the unused `on_lavalink_callback` method from `src/core/bot.py` to avoid redundancy, as it is now implemented in the music cog.
* Renamed the `current_datetime` property to `now` in `src/core/bot.py` for better clarity and consistency.

### Error Logging Improvements:
* Updated `embed_log` and `error_log` methods in `src/core/bot.py` to initialize `log_channel` dynamically if not already set, ensuring error messages are logged only if the channel exists. [[1]](diffhunk://#diff-ffc3bf5e57aee8835dde5339d1a17baeaa2964883b83ac441da1094c8569ba45R190-R194) [[2]](diffhunk://#diff-ffc3bf5e57aee8835dde5339d1a17baeaa2964883b83ac441da1094c8569ba45L211-R209)

### Additional Enhancements:
* Added `chunk_guilds_at_startup=False` to the bot's initialization in `src/core/bot.py` to allow manual control over guild chunking.